### PR TITLE
Fix cross-tile bug

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Setup | Rust cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Build | Test
+        run: cargo test --all-targets --all-features
+
       - name: Hygiene | Formatting
         run: cargo fmt -- --check
 
       - name: Hygiene | Clippy
-        run: cargo clippy -- -Dclippy::all -Dwarnings
+        run: cargo clippy --all-targets --all-features -- -Dclippy::all -Dwarnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build | Test
-        run: cargo test --all-targets --all-features
+        run: cargo test
 
       - name: Hygiene | Formatting
         run: cargo fmt -- --check

--- a/nasadem/src/lib.rs
+++ b/nasadem/src/lib.rs
@@ -244,9 +244,13 @@ impl Tile {
 
     /// Returns the sample at the given geo coordinates.
     pub fn get(&self, coord: Coord<C>) -> Option<i16> {
-        let idx_2d @ (idx_x, idx_y) = self.coord_to_xy(coord);
-        if idx_x < self.dimensions.0 && idx_y < self.dimensions.1 {
-            let idx_1d = self.xy_to_linear_index(idx_2d);
+        let (idx_x, idx_y) = self.coord_to_xy(coord);
+        if 0 <= idx_x
+            && idx_x < self.dimensions.0 as isize
+            && 0 <= idx_y
+            && idx_y < self.dimensions.1 as isize
+        {
+            let idx_1d = self.xy_to_linear_index((idx_x as usize, idx_y as usize));
             Some(self.samples.get_unchecked(idx_1d))
         } else {
             None
@@ -255,8 +259,8 @@ impl Tile {
 
     /// Returns the sample at the given geo coordinates.
     pub fn get_unchecked(&self, coord: Coord<C>) -> i16 {
-        let idx_2d = self.coord_to_xy(coord);
-        let idx_1d = self.xy_to_linear_index(idx_2d);
+        let (idx_x, idx_y) = self.coord_to_xy(coord);
+        let idx_1d = self.xy_to_linear_index((idx_x as usize, idx_y as usize));
         self.samples.get_unchecked(idx_1d)
     }
 
@@ -273,15 +277,15 @@ impl Tile {
         self.samples.get_unchecked(idx_1d)
     }
 
-    fn coord_to_xy(&self, coord: Coord<C>) -> (usize, usize) {
+    fn coord_to_xy(&self, coord: Coord<C>) -> (isize, isize) {
         let c = ARCSEC_PER_DEG / C::from(self.resolution);
         // TODO: do we need to compensate for cell width. If so, does
         //       the following accomplish that? It seems to in the
         //       Mt. Washington test.
         let sample_center_compensation = 1. / (c * 2.);
         let cc = sample_center_compensation;
-        let x = ((coord.x - self.sw_corner_center.x + cc) * c) as usize;
-        let y = ((coord.y - self.sw_corner_center.y + cc) * c) as usize;
+        let x = ((coord.x - self.sw_corner_center.x + cc) * c) as isize;
+        let y = ((coord.y - self.sw_corner_center.y + cc) * c) as isize;
         (x, y)
     }
 

--- a/nasadem/src/lib.rs
+++ b/nasadem/src/lib.rs
@@ -421,6 +421,21 @@ mod _1_arc_second {
     }
 
     #[test]
+    fn test_out_of_bounds_get_returns_none() {
+        let mut path = one_arcsecond_dir();
+        path.push("N44W072.hgt");
+        let tile = Tile::load(path).unwrap();
+        // Assert coordinate a smidge north of tile returns None.
+        assert_eq!(tile.get(Coord { x: -71.5, y: 45.1 }), None);
+        // Assert coordinate a smidge east of tile returns None.
+        assert_eq!(tile.get(Coord { x: -70.9, y: 44.5 }), None);
+        // Assert coordinate a smidge south of tile returns None.
+        assert_eq!(tile.get(Coord { x: -71.5, y: 43.9 }), None);
+        // Assert coordinate a smidge west of tile returns None.
+        assert_eq!(tile.get(Coord { x: -72.1, y: 44.5 }), None);
+    }
+
+    #[test]
     fn test_tile_index() {
         let mut path = one_arcsecond_dir();
         path.push("N44W072.hgt");
@@ -507,6 +522,21 @@ mod _3_arc_second {
         let mut path = three_arcsecond_dir();
         path.push("N44W072.hgt");
         Tile::load(path).unwrap();
+    }
+
+    #[test]
+    fn test_out_of_bounds_get_returns_none() {
+        let mut path = three_arcsecond_dir();
+        path.push("N44W072.hgt");
+        let tile = Tile::load(path).unwrap();
+        // Assert coordinate a smidge north of tile returns None.
+        assert_eq!(tile.get(Coord { x: -71.5, y: 45.1 }), None);
+        // Assert coordinate a smidge east of tile returns None.
+        assert_eq!(tile.get(Coord { x: -70.9, y: 44.5 }), None);
+        // Assert coordinate a smidge south of tile returns None.
+        assert_eq!(tile.get(Coord { x: -71.5, y: 43.9 }), None);
+        // Assert coordinate a smidge west of tile returns None.
+        assert_eq!(tile.get(Coord { x: -72.1, y: 44.5 }), None);
     }
 
     #[test]

--- a/nasadem/src/lib.rs
+++ b/nasadem/src/lib.rs
@@ -188,13 +188,18 @@ impl Tile {
         })
     }
 
-    pub fn tombstone(sw_corner: Coord<C>) -> Self {
+    pub fn tombstone(sw_corner: Coord<i16>) -> Self {
+        let sw_corner = Coord {
+            x: sw_corner.x as C,
+            y: sw_corner.y as C,
+        };
+
         let (resolution, dimensions) = (3, (1201, 1201));
 
         #[allow(clippy::cast_precision_loss)]
         let ne_corner = Coord {
-            y: sw_corner.y + (dimensions.0 as C * C::from(resolution)) / ARCSEC_PER_DEG,
-            x: sw_corner.x + (dimensions.1 as C * C::from(resolution)) / ARCSEC_PER_DEG,
+            y: sw_corner.y as C + (dimensions.0 as C * C::from(resolution)) / ARCSEC_PER_DEG,
+            x: sw_corner.x as C + (dimensions.1 as C * C::from(resolution)) / ARCSEC_PER_DEG,
         };
 
         let sample_store = SampleStore::Tombstone;

--- a/terrain/src/profile.rs
+++ b/terrain/src/profile.rs
@@ -307,7 +307,6 @@ mod tests {
             .end(end)
             .build(&tile_source)
             .unwrap();
-        println!("{:#?}", profile);
         assert_eq!(36, profile.great_circle.len());
     }
 }


### PR DESCRIPTION
Tile::get returns Some even when the coordinates are out of bounds, leading to reusing the first tile over and over

# Reference

![Screenshot 2023-09-29 at 3 43 07 PM](https://github.com/JayKickliter/geoprof/assets/2551201/e90ad434-6798-40be-b35a-374bf93f91df)

# Before PR

![tahoe_before](https://github.com/JayKickliter/geoprof/assets/2551201/b824b0d6-6c17-49d9-8258-3139bc976f24)

# After

![tahoe_after](https://github.com/JayKickliter/geoprof/assets/2551201/4f909dcd-44f3-4144-949d-ea457ee269eb)

