### PR TITLE
Add RF propagation crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,4 +32,4 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Hygiene | Clippy
-        run: cargo clippy --all-targets --all-features -- -Dwarnings -Dclippy::all -Dclippy::cargo_common_metadata
+        run: cargo clippy --all-targets --all-features -- -Dwarnings -Dclippy::all -Dclippy::pedantic -Aclippy::module_name_repetitions -Aclippy::missing_panics_doc -Aclippy::missing_errors_doc -Aclippy::must_use_candidate -Aclippy::similar_names

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "geopath",
   "nasadem",
+  "propah",
   "terrain",
 ]
 resolver = "2"

--- a/geopath/Cargo.toml
+++ b/geopath/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.10"
 geo        = { workspace = true }
 itertools  = "0.10"
 num-traits = { workspace = true }
+propah     = { path = "../propah" }
 rfprop     = { git = "https://github.com/JayKickliter/Signal-Server", branch = "master" }
 serde      = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/geopath/src/main.rs
+++ b/geopath/src/main.rs
@@ -230,11 +230,11 @@ where
 
 /// A common represention of both native and rfprop profiles.
 struct CommonProfile<T: CoordFloat> {
-    great_circle: Vec<Point<T>>,
-    distances_m: Vec<T>,
-    los_elev_m: Vec<T>,
-    terrain_elev_m: Vec<T>,
-    fresnel_zone_m: Vec<T>,
+    great_circle: Box<[Point<T>]>,
+    distances_m: Box<[T]>,
+    los_elev_m: Box<[T]>,
+    terrain_elev_m: Box<[T]>,
+    fresnel_zone_m: Box<[T]>,
 }
 
 impl<T: CoordFloat> From<Point2Point<T>> for CommonProfile<T> {
@@ -299,11 +299,11 @@ impl From<TerrainProfile> for CommonProfile<f64> {
             .take(terrain.len())
             .collect();
         Self {
-            distances_m: distance,
+            distances_m: distance.into(),
             great_circle,
-            los_elev_m: los,
-            terrain_elev_m: terrain,
-            fresnel_zone_m: fresnel,
+            los_elev_m: los.into(),
+            terrain_elev_m: terrain.into(),
+            fresnel_zone_m: fresnel.into(),
         }
     }
 }

--- a/geopath/src/options.rs
+++ b/geopath/src/options.rs
@@ -5,6 +5,7 @@ use std::{path::PathBuf, str::FromStr};
 
 /// Generate point-to-point terrain profiles.
 #[derive(Parser, Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Cli {
     /// Directory elevation tiles.
     #[arg(short, long)]

--- a/geopath/src/options.rs
+++ b/geopath/src/options.rs
@@ -37,6 +37,14 @@ pub struct Cli {
     #[arg(long)]
     pub dest: LatLonAlt,
 
+    /// Add fresnel zone `n` to the plot.
+    #[arg(long = "zone", short = 'z')]
+    pub fresnel_zone: Option<u8>,
+
+    /// Frequency for fresnel zone calculation.
+    #[arg(long, short)]
+    pub frequency: Option<f64>,
+
     #[command(subcommand)]
     pub cmd: Command,
 }

--- a/geopath/src/options.rs
+++ b/geopath/src/options.rs
@@ -37,10 +37,6 @@ pub struct Cli {
     #[arg(long)]
     pub dest: LatLonAlt,
 
-    /// Add fresnel zone `n` to the plot.
-    #[arg(long = "zone", short = 'z')]
-    pub fresnel_zone: Option<u8>,
-
     /// Frequency for fresnel zone calculation.
     #[arg(long, short)]
     pub frequency: Option<f64>,

--- a/nasadem/src/lib.rs
+++ b/nasadem/src/lib.rs
@@ -197,8 +197,8 @@ impl Tile {
 
     pub fn tombstone(sw_corner: Coord<i16>) -> Self {
         let sw_corner_center = Coord {
-            x: sw_corner.x as C,
-            y: sw_corner.y as C,
+            x: C::from(sw_corner.x),
+            y: C::from(sw_corner.y),
         };
 
         let (resolution, dimensions) = (3, (1201, 1201));
@@ -252,11 +252,13 @@ impl Tile {
     /// Returns the sample at the given geo coordinates.
     pub fn get(&self, coord: Coord<C>) -> Option<i16> {
         let (idx_x, idx_y) = self.coord_to_xy(coord);
+        #[allow(clippy::cast_possible_wrap)]
         if 0 <= idx_x
             && idx_x < self.dimensions.0 as isize
             && 0 <= idx_y
             && idx_y < self.dimensions.1 as isize
         {
+            #[allow(clippy::cast_sign_loss)]
             let idx_1d = self.xy_to_linear_index((idx_x as usize, idx_y as usize));
             Some(self.samples.get_unchecked(idx_1d))
         } else {
@@ -267,6 +269,7 @@ impl Tile {
     /// Returns the sample at the given geo coordinates.
     pub fn get_unchecked(&self, coord: Coord<C>) -> i16 {
         let (idx_x, idx_y) = self.coord_to_xy(coord);
+        #[allow(clippy::cast_sign_loss)]
         let idx_1d = self.xy_to_linear_index((idx_x as usize, idx_y as usize));
         self.samples.get_unchecked(idx_1d)
     }
@@ -291,7 +294,9 @@ impl Tile {
         //       Mt. Washington test.
         let sample_center_compensation = 1. / (c * 2.);
         let cc = sample_center_compensation;
+        #[allow(clippy::cast_possible_truncation)]
         let x = ((coord.x - self.sw_corner_center.x + cc) * c) as isize;
+        #[allow(clippy::cast_possible_truncation)]
         let y = ((coord.y - self.sw_corner_center.y + cc) * c) as isize;
         (x, y)
     }

--- a/nasadem/src/lib.rs
+++ b/nasadem/src/lib.rs
@@ -26,6 +26,13 @@ use std::{
     sync::atomic::{AtomicI16, Ordering},
 };
 
+/// Base floating point type used for all coordinates and calculations.
+///
+/// Note: this _could_ be a generic parameter, but doing so makes the
+/// library more complicated. While f32 vs f64 does make a measurable
+/// differnece when walking paths across tiles (see `Profile` type in
+/// the `terrain` crate), benchmarking shows that switching NASADEMs
+/// to `f32` has no effect.
 pub type C = f64;
 
 const ARCSEC_PER_DEG: C = 3600.0;

--- a/propah/Cargo.toml
+++ b/propah/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+categories  = ["science"]
+description = "Radio frequency propogation modeling"
+edition     = "2021"
+homepage    = "https://github.com/jaykickliter/geoprof"
+keywords    = ["gis", "geo", "geography", "geospatial"]
+license     = "MIT OR Apache-2.0"
+name        = "propah"
+readme      = "README.md"
+repository  = "https://github.com/jaykickliter/geoprof"
+version     = "0.1.0"
+
+[dependencies]
+terrain = { path = "../terrain" }

--- a/propah/Cargo.toml
+++ b/propah/Cargo.toml
@@ -11,5 +11,9 @@ repository  = "https://github.com/jaykickliter/geoprof"
 version     = "0.1.0"
 
 [dependencies]
+
+geo        = { workspace = true }
+nasadem    = { path = "../nasadem" }
 num-traits = { workspace = true }
 terrain    = { path = "../terrain" }
+thiserror  = { workspace = true }

--- a/propah/Cargo.toml
+++ b/propah/Cargo.toml
@@ -11,4 +11,5 @@ repository  = "https://github.com/jaykickliter/geoprof"
 version     = "0.1.0"
 
 [dependencies]
-terrain = { path = "../terrain" }
+num-traits = { workspace = true }
+terrain    = { path = "../terrain" }

--- a/propah/Cargo.toml
+++ b/propah/Cargo.toml
@@ -13,7 +13,6 @@ version     = "0.1.0"
 [dependencies]
 
 geo        = { workspace = true }
-nasadem    = { path = "../nasadem" }
 num-traits = { workspace = true }
 terrain    = { path = "../terrain" }
 thiserror  = { workspace = true }

--- a/propah/README.md
+++ b/propah/README.md
@@ -1,5 +1,8 @@
 # Radio Frequency Propogation Modeling
 
+This crate builds on top of `terrain`, using the terrain data to model
+RF propagation.
+
 # License
 
 Licensed under either of

--- a/propah/README.md
+++ b/propah/README.md
@@ -1,0 +1,15 @@
+# Radio Frequency Propogation Modeling
+
+# License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../LICENSE-MIT) or http://opensource.org/licenses/MIT) at your option.
+
+# Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the
+Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.

--- a/propah/src/error.rs
+++ b/propah/src/error.rs
@@ -1,0 +1,11 @@
+use terrain::TerrainError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PropahError {
+    #[error("missing required parameter '{0}'")]
+    Builder(&'static str),
+
+    #[error("{0}")]
+    Terrain(#[from] TerrainError),
+}

--- a/propah/src/fresnel.rs
+++ b/propah/src/fresnel.rs
@@ -1,3 +1,82 @@
+use num_traits::{AsPrimitive, Float};
+use std::{iter::Iterator, num::NonZeroU8, ops::Range};
+
+/// Speed of light in m/s
+const C: usize = 299_792_458;
+
+/// Represents the lower nth fresnel zone of a radio link.
+#[derive(Debug)]
+pub struct FresnelZone<T> {
+    /// Which fresnel zone we're interested in.
+    _zone: NonZeroU8,
+    wavelength: T,
+    _distance_m: T,
+}
+
+impl<T> FresnelZone<T> {
+    /// Returns a new FesnelZone object.
+    pub fn new(zone: NonZeroU8, f_hz: T, distance_m: T) -> Self
+    where
+        T: Float + 'static,
+        usize: AsPrimitive<T>,
+    {
+        let wavelength = C.as_() / f_hz;
+        Self {
+            _zone: zone,
+            wavelength,
+            _distance_m: distance_m,
+        }
+    }
+
+    /// Returns a new FresnelZoneIter of length `len`.
+    pub fn iter(&self, len: usize) -> FresnelZoneIter<T>
+    where
+        T: Copy,
+    {
+        FresnelZoneIter {
+            _zone: self._zone,
+            wavelength: self.wavelength,
+            range: 0..len,
+        }
+    }
+}
+
 /// An iterator for a fresnel zone the specified frequency.
 #[derive(Debug)]
-pub struct FresnelIter {}
+pub struct FresnelZoneIter<T> {
+    /// Which fresnel zone we're interested in.
+    _zone: NonZeroU8,
+    wavelength: T,
+    range: Range<usize>,
+}
+
+impl<T: Float + 'static> Iterator for FresnelZoneIter<T>
+where
+    usize: AsPrimitive<T>,
+{
+    type Item = T;
+    fn next(&mut self) -> Option<T> {
+        self.range.next().map(|n| n.as_() * self.wavelength)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FresnelZone, NonZeroU8};
+
+    #[test]
+    fn test_fresnel_zone_iter() {
+        let iter = FresnelZone::new(NonZeroU8::new(1).unwrap(), 1.0, 10e3).iter(5);
+        let expected = &[0., 1., 2., 3., 4.];
+        assert!(iter.zip(expected.iter()).all(|(l, &e)| {
+            debug_assert_eq!(l, e);
+            l == e
+        }));
+    }
+
+    #[test]
+    fn test_zero_len_fresnel_zone_iter() {
+        let mut iter = FresnelZone::new(NonZeroU8::new(1).unwrap(), 1.0, 10e3).iter(0);
+        assert!(iter.next().is_none());
+    }
+}

--- a/propah/src/fresnel.rs
+++ b/propah/src/fresnel.rs
@@ -1,8 +1,27 @@
+use crate::C;
 use num_traits::{AsPrimitive, Float};
 use std::{iter::Iterator, ops::Range};
 
-/// Speed of light in m/s
-const C: usize = 299_792_458;
+/// Returnes the EM wavelength for the provided `freq_hz`.
+pub fn freq_to_wavelen<T>(freq_hz: T) -> T
+where
+    T: Float + 'static,
+    usize: AsPrimitive<T>,
+{
+    C.as_() / freq_hz
+}
+
+/// Returns the nth fresnel `zone` thickness at distance `d_m` meters
+/// from the transmitter out of `total_d_m` meters.
+#[inline]
+pub fn fresnel<T>(zone: T, wavelen: T, d_m: T, total_d_m: T) -> T
+where
+    T: Float,
+{
+    let d1 = d_m;
+    let d2 = total_d_m - d1;
+    (zone * wavelen * d1 * d2 / total_d_m).sqrt()
+}
 
 /// Represents the lower nth fresnel zone of a radio link.
 #[derive(Debug)]

--- a/propah/src/fresnel.rs
+++ b/propah/src/fresnel.rs
@@ -1,0 +1,3 @@
+/// An iterator for a fresnel zone the specified frequency.
+#[derive(Debug)]
+pub struct FresnelIter {}

--- a/propah/src/fresnel.rs
+++ b/propah/src/fresnel.rs
@@ -1,5 +1,5 @@
 use num_traits::{AsPrimitive, Float};
-use std::{iter::Iterator, num::NonZeroU8, ops::Range};
+use std::{iter::Iterator, ops::Range};
 
 /// Speed of light in m/s
 const C: usize = 299_792_458;
@@ -8,34 +8,36 @@ const C: usize = 299_792_458;
 #[derive(Debug)]
 pub struct FresnelZone<T> {
     /// Which fresnel zone we're interested in.
-    _zone: NonZeroU8,
+    zone: u8,
     wavelength: T,
-    _distance_m: T,
+    distance_m: T,
 }
 
 impl<T> FresnelZone<T> {
     /// Returns a new FesnelZone object.
-    pub fn new(zone: NonZeroU8, f_hz: T, distance_m: T) -> Self
+    pub fn new(zone: u8, f_hz: T, distance_m: T) -> Self
     where
         T: Float + 'static,
         usize: AsPrimitive<T>,
     {
         let wavelength = C.as_() / f_hz;
         Self {
-            _zone: zone,
+            zone,
             wavelength,
-            _distance_m: distance_m,
+            distance_m,
         }
     }
 
     /// Returns a new FresnelZoneIter of length `len`.
     pub fn iter(&self, len: usize) -> FresnelZoneIter<T>
     where
-        T: Copy,
+        T: Copy + 'static,
+        u8: AsPrimitive<T>,
     {
         FresnelZoneIter {
-            _zone: self._zone,
+            zone: self.zone.as_(),
             wavelength: self.wavelength,
+            distance_m: self.distance_m,
             range: 0..len,
         }
     }
@@ -45,38 +47,60 @@ impl<T> FresnelZone<T> {
 #[derive(Debug)]
 pub struct FresnelZoneIter<T> {
     /// Which fresnel zone we're interested in.
-    _zone: NonZeroU8,
+    zone: T,
     wavelength: T,
     range: Range<usize>,
+    distance_m: T,
 }
 
-impl<T: Float + 'static> Iterator for FresnelZoneIter<T>
+impl<T> Iterator for FresnelZoneIter<T>
 where
+    T: Float + 'static,
     usize: AsPrimitive<T>,
 {
     type Item = T;
+
+    #[inline]
     fn next(&mut self) -> Option<T> {
-        self.range.next().map(|n| n.as_() * self.wavelength)
+        self.range.next().map(|n| {
+            let d1 = self.distance_m * (n.as_() / (self.range.end - 1).as_());
+            let d2 = self.distance_m - d1;
+            (self.zone * self.wavelength * d1 * d2 / (self.distance_m)).sqrt()
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{FresnelZone, NonZeroU8};
-
-    #[test]
-    fn test_fresnel_zone_iter() {
-        let iter = FresnelZone::new(NonZeroU8::new(1).unwrap(), 1.0, 10e3).iter(5);
-        let expected = &[0., 1., 2., 3., 4.];
-        assert!(iter.zip(expected.iter()).all(|(l, &e)| {
-            debug_assert_eq!(l, e);
-            l == e
-        }));
-    }
+    use super::FresnelZone;
 
     #[test]
     fn test_zero_len_fresnel_zone_iter() {
-        let mut iter = FresnelZone::new(NonZeroU8::new(1).unwrap(), 1.0, 10e3).iter(0);
+        let mut iter = FresnelZone::new(1, 1.0, 10e3).iter(0);
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_1st_fresnel_zone() {
+        let mut iter = FresnelZone::new(1, 900e6, 1e3).iter(3);
+        assert_eq!(iter.next(), Some(0.0));
+        assert_eq!(iter.next(), Some(9.125551094469735));
+        assert_eq!(iter.next(), Some(0.0));
+    }
+
+    #[test]
+    fn test_2nd_fresnel_zone() {
+        let mut iter = FresnelZone::new(2, 900e6, 1e3).iter(3);
+        assert_eq!(iter.next(), Some(0.0));
+        assert_eq!(iter.next(), Some(12.90547812192774));
+        assert_eq!(iter.next(), Some(0.0));
+    }
+
+    #[test]
+    fn test_3rd_fresnel_zone() {
+        let mut iter = FresnelZone::new(3, 900e6, 1e3).iter(3);
+        assert_eq!(iter.next(), Some(0.0));
+        assert_eq!(iter.next(), Some(15.805918142687355));
+        assert_eq!(iter.next(), Some(0.0));
     }
 }

--- a/propah/src/fresnel.rs
+++ b/propah/src/fresnel.rs
@@ -33,7 +33,7 @@ pub struct FresnelZone<T> {
 }
 
 impl<T> FresnelZone<T> {
-    /// Returns a new FesnelZone object.
+    /// Returns a new `FesnelZone` object.
     pub fn new(zone: u8, f_hz: T, distance_m: T) -> Self
     where
         T: Float + 'static,
@@ -47,7 +47,8 @@ impl<T> FresnelZone<T> {
         }
     }
 
-    /// Returns a new FresnelZoneIter of length `len`.
+    /// Returns a new `FresnelZoneIter` of length `len`.
+    #[allow(clippy::iter_not_returning_iterator)]
     pub fn iter(&self, len: usize) -> FresnelZoneIter<T>
     where
         T: Copy + 'static,
@@ -103,7 +104,7 @@ mod tests {
     fn test_1st_fresnel_zone() {
         let mut iter = FresnelZone::new(1, 900e6, 1e3).iter(3);
         assert_eq!(iter.next(), Some(0.0));
-        assert_eq!(iter.next(), Some(9.125551094469735));
+        assert_eq!(iter.next(), Some(9.125_551_094_469_735));
         assert_eq!(iter.next(), Some(0.0));
     }
 
@@ -111,7 +112,7 @@ mod tests {
     fn test_2nd_fresnel_zone() {
         let mut iter = FresnelZone::new(2, 900e6, 1e3).iter(3);
         assert_eq!(iter.next(), Some(0.0));
-        assert_eq!(iter.next(), Some(12.90547812192774));
+        assert_eq!(iter.next(), Some(12.905_478_121_927_74));
         assert_eq!(iter.next(), Some(0.0));
     }
 
@@ -119,7 +120,7 @@ mod tests {
     fn test_3rd_fresnel_zone() {
         let mut iter = FresnelZone::new(3, 900e6, 1e3).iter(3);
         assert_eq!(iter.next(), Some(0.0));
-        assert_eq!(iter.next(), Some(15.805918142687355));
+        assert_eq!(iter.next(), Some(15.805_918_142_687_355));
         assert_eq!(iter.next(), Some(0.0));
     }
 }

--- a/propah/src/lib.rs
+++ b/propah/src/lib.rs
@@ -7,7 +7,10 @@ pub mod fresnel;
 mod math;
 pub mod p2p;
 
-pub use crate::{error::PropahError, p2p::Point2Point};
+pub use {
+    crate::{error::PropahError, p2p::Point2Point},
+    geo, terrain,
+};
 
 /// Speed of light in m/s
 const C: usize = 299_792_458;

--- a/propah/src/lib.rs
+++ b/propah/src/lib.rs
@@ -2,7 +2,12 @@
 //!
 //! `propah` provides radio propogation modeling routines.
 
+mod error;
 pub mod fresnel;
+mod math;
 pub mod p2p;
 
-pub use p2p::Point2Point;
+pub use crate::{error::PropahError, p2p::Point2Point};
+
+/// Speed of light in m/s
+const C: usize = 299_792_458;

--- a/propah/src/lib.rs
+++ b/propah/src/lib.rs
@@ -1,0 +1,8 @@
+//! # Radio Frequency Propogation
+//!
+//! `propah` provides radio propogation modeling routines.
+
+pub mod fresnel;
+pub mod p2p;
+
+pub use p2p::Point2Point;

--- a/propah/src/math.rs
+++ b/propah/src/math.rs
@@ -1,0 +1,9 @@
+use num_traits::{Float, FromPrimitive};
+
+pub fn _linspace<T>(y_start: T, y_end: T, n: usize) -> impl Iterator<Item = T>
+where
+    T: Float + FromPrimitive,
+{
+    let dy = (y_end - y_start) / T::from(n - 1).unwrap();
+    (0..n).map(move |x| y_start + T::from(x).unwrap() * dy)
+}

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -1,3 +1,174 @@
+use crate::{
+    error::PropahError,
+    fresnel::{freq_to_wavelen, fresnel},
+};
+use geo::{Coord, CoordFloat, Point};
+use num_traits::{AsPrimitive, Float, FloatConst, FromPrimitive};
+use terrain::{Profile, Tiles};
+
 /// Point to point propogation estimate.
 #[derive(Debug, Clone)]
-pub struct Point2Point {}
+pub struct Point2Point<C: CoordFloat> {
+    /// Incremental path distance for all following vectors.
+    pub distances_m: Vec<C>,
+
+    /// Location of step along the great circle route from `start` to
+    /// `end`.
+    pub great_circle: Vec<Point<C>>,
+
+    /// Elevation at each step along the great circle route from
+    /// `start` to `end`.
+    pub terrain_elev_m: Vec<C>,
+
+    /// A straight line from `start` to `end`.
+    pub los_elev_m: Vec<C>,
+
+    /// Fresnel zone thickness from `start` to `end`.
+    pub fresnel_zone_m: Vec<C>,
+}
+
+impl<C> Point2Point<C>
+where
+    C: CoordFloat,
+{
+    pub fn builder() -> Point2PointBuilder<C> {
+        Point2PointBuilder {
+            freq_hz: None,
+            start: None,
+            max_step_m: None,
+            end: None,
+            start_alt_m: C::zero(),
+            end_alt_m: C::zero(),
+            earth_curve: false,
+            normalize: false,
+        }
+    }
+}
+
+pub struct Point2PointBuilder<C: CoordFloat = f32> {
+    /// Transmitter frequency (required).
+    freq_hz: Option<C>,
+
+    /// Start point of the path (required).
+    start: Option<Coord<C>>,
+
+    /// Maximum distance between points (required).
+    max_step_m: Option<C>,
+
+    /// End point of the path (required).
+    end: Option<Coord<C>>,
+
+    /// Starting altitude above ground (meters, defaults to 0).
+    start_alt_m: C,
+
+    /// Starting altitude above ground (meters, defaults to 0).
+    end_alt_m: C,
+
+    /// Add earth curvature (defaults to false).
+    earth_curve: bool,
+
+    /// Place virtual earth curve as the highest and center point of
+    /// the output (defaults to false; has no effect if `earth_curve`
+    /// is `false`).
+    normalize: bool,
+}
+
+impl<C> Point2PointBuilder<C>
+where
+    C: CoordFloat + FromPrimitive,
+    f64: From<C>,
+{
+    /// Frequency of signal (Hz, required).
+    pub fn freq(mut self, freq_hz: C) -> Self {
+        self.freq_hz = Some(freq_hz);
+        self
+    }
+
+    /// Start point of the path (required).
+    pub fn start(mut self, coord: Coord<C>) -> Self {
+        self.start = Some(coord);
+        self
+    }
+
+    /// Starting altitude above ground (meters, defaults to 0).
+    pub fn start_alt(mut self, meters: C) -> Self {
+        self.start_alt_m = meters;
+        self
+    }
+
+    /// Maximum distance between points (required).
+    pub fn max_step(mut self, meters: C) -> Self {
+        self.max_step_m = Some(meters);
+        self
+    }
+
+    /// End point of the path (required).
+    pub fn end(mut self, coord: Coord<C>) -> Self {
+        self.end = Some(coord);
+        self
+    }
+
+    /// Starting altitude above ground (meters, defaults to 0).
+    pub fn end_alt(mut self, meters: C) -> Self {
+        self.end_alt_m = meters;
+        self
+    }
+
+    /// Add earth curvature (defaults to false).
+    pub fn earth_curve(mut self, add_curve: bool) -> Self {
+        self.earth_curve = add_curve;
+        self
+    }
+
+    /// Place virtual earth curve as the highest and center point of
+    /// the output (defaults to false; has no effect if `earth_curve`
+    /// is `false`).
+    pub fn normalize(mut self, normalize: bool) -> Self {
+        self.normalize = normalize;
+        self
+    }
+
+    pub fn build(&self, tiles: &Tiles) -> Result<Point2Point<C>, PropahError>
+    where
+        C: FloatConst + Float + 'static,
+        usize: AsPrimitive<C>,
+        C: AsPrimitive<usize>,
+    {
+        let freq_hz = self.freq_hz.ok_or(PropahError::Builder("freq"))?;
+        let start = self.start.ok_or(PropahError::Builder("start"))?;
+        let max_step_m = self.max_step_m.ok_or(PropahError::Builder("max_step"))?;
+        let end = self.end.ok_or(PropahError::Builder("end"))?;
+
+        let Profile {
+            distances_m,
+            great_circle,
+            terrain_elev_m,
+            los_elev_m,
+        } = Profile::builder()
+            .start(start)
+            .start_alt(self.start_alt_m)
+            .max_step(max_step_m)
+            .end(end)
+            .end_alt(self.end_alt_m)
+            .earth_curve(self.earth_curve)
+            .normalize(self.normalize)
+            .build(tiles)?;
+
+        // Unwrap is fine as profiles always have at least two points.
+        let total_distance_m = *distances_m.last().unwrap();
+        let wavelen = freq_to_wavelen(freq_hz);
+        let fresnel_zone_1 = 1.as_();
+        let fresnel_zone_m = distances_m
+            .iter()
+            .map(|&d1| fresnel(fresnel_zone_1, wavelen, d1, total_distance_m))
+            .collect();
+
+        Ok(Point2Point {
+            distances_m,
+            great_circle,
+            terrain_elev_m,
+            los_elev_m,
+            fresnel_zone_m,
+        })
+    }
+}

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -1,0 +1,3 @@
+/// Point to point propogation estimate.
+#[derive(Debug, Clone)]
+pub struct Point2Point {}

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -1,8 +1,8 @@
+use crate::geo::{Coord, CoordFloat, Point};
 use crate::{
     error::PropahError,
     fresnel::{freq_to_wavelen, fresnel},
 };
-use geo::{Coord, CoordFloat, Point};
 use num_traits::{AsPrimitive, Float, FloatConst, FromPrimitive};
 use terrain::{Profile, Tiles};
 

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -79,42 +79,49 @@ where
     f64: From<C>,
 {
     /// Frequency of signal (Hz, required).
+    #[must_use]
     pub fn freq(mut self, freq_hz: C) -> Self {
         self.freq_hz = Some(freq_hz);
         self
     }
 
     /// Start point of the path (required).
+    #[must_use]
     pub fn start(mut self, coord: Coord<C>) -> Self {
         self.start = Some(coord);
         self
     }
 
     /// Starting altitude above ground (meters, defaults to 0).
+    #[must_use]
     pub fn start_alt(mut self, meters: C) -> Self {
         self.start_alt_m = meters;
         self
     }
 
     /// Maximum distance between points (required).
+    #[must_use]
     pub fn max_step(mut self, meters: C) -> Self {
         self.max_step_m = Some(meters);
         self
     }
 
     /// End point of the path (required).
+    #[must_use]
     pub fn end(mut self, coord: Coord<C>) -> Self {
         self.end = Some(coord);
         self
     }
 
     /// Starting altitude above ground (meters, defaults to 0).
+    #[must_use]
     pub fn end_alt(mut self, meters: C) -> Self {
         self.end_alt_m = meters;
         self
     }
 
     /// Add earth curvature (defaults to false).
+    #[must_use]
     pub fn earth_curve(mut self, add_curve: bool) -> Self {
         self.earth_curve = add_curve;
         self
@@ -123,6 +130,7 @@ where
     /// Place virtual earth curve as the highest and center point of
     /// the output (defaults to false; has no effect if `earth_curve`
     /// is `false`).
+    #[must_use]
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
         self

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -10,21 +10,21 @@ use terrain::{Profile, Tiles};
 #[derive(Debug, Clone)]
 pub struct Point2Point<C: CoordFloat> {
     /// Incremental path distance for all following vectors.
-    pub distances_m: Vec<C>,
+    pub distances_m: Box<[C]>,
 
     /// Location of step along the great circle route from `start` to
     /// `end`.
-    pub great_circle: Vec<Point<C>>,
+    pub great_circle: Box<[Point<C>]>,
 
     /// Elevation at each step along the great circle route from
     /// `start` to `end`.
-    pub terrain_elev_m: Vec<C>,
+    pub terrain_elev_m: Box<[C]>,
 
     /// A straight line from `start` to `end`.
-    pub los_elev_m: Vec<C>,
+    pub los_elev_m: Box<[C]>,
 
     /// Fresnel zone thickness from `start` to `end`.
-    pub fresnel_zone_m: Vec<C>,
+    pub fresnel_zone_m: Box<[C]>,
 }
 
 impl<C> Point2Point<C>
@@ -166,11 +166,17 @@ where
         let total_distance_m = *distances_m.last().unwrap();
         let wavelen = freq_to_wavelen(freq_hz);
         let fresnel_zone_1 = 1.as_();
-        let fresnel_zone_m = distances_m
+        let fresnel_zone_m: Box<[C]> = distances_m
             .iter()
             .map(|&d1| fresnel(fresnel_zone_1, wavelen, d1, total_distance_m))
             .collect();
 
+        assert!(
+            distances_m.len() == great_circle.len()
+                && great_circle.len() == terrain_elev_m.len()
+                && terrain_elev_m.len() == los_elev_m.len()
+                && los_elev_m.len() == fresnel_zone_m.len()
+        );
         Ok(Point2Point {
             distances_m,
             great_circle,

--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -4,7 +4,7 @@ use crate::{
     fresnel::{freq_to_wavelen, fresnel},
 };
 use num_traits::{AsPrimitive, Float, FloatConst, FromPrimitive};
-use terrain::{Profile, Tiles};
+use terrain::{constants::MEAN_EARTH_RADIUS, Profile, Tiles};
 
 /// Point to point propogation estimate.
 #[derive(Debug, Clone)]
@@ -41,6 +41,7 @@ where
             end_alt_m: C::zero(),
             earth_curve: false,
             normalize: false,
+            earth_radius: C::from(MEAN_EARTH_RADIUS).unwrap(),
         }
     }
 }
@@ -71,6 +72,9 @@ pub struct Point2PointBuilder<C: CoordFloat = f32> {
     /// the output (defaults to false; has no effect if `earth_curve`
     /// is `false`).
     normalize: bool,
+
+    /// Earth radius, defaults to [MEAN_EARTH_RADIUS].
+    earth_radius: C,
 }
 
 impl<C> Point2PointBuilder<C>
@@ -133,6 +137,13 @@ where
     #[must_use]
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
+        self
+    }
+
+    /// Earth radius (meters, defaults to [`MEAN_EARTH_RADIUS`]).
+    #[must_use]
+    pub fn earth_radius(mut self, earth_radius_m: C) -> Self {
+        self.earth_radius = earth_radius_m;
         self
     }
 

--- a/terrain/benches/benchmarks.rs
+++ b/terrain/benches/benchmarks.rs
@@ -24,27 +24,27 @@ fn memmap_terrain_profile_f32(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("Profile<f32>");
 
-    let _2_4km = (
-        coord!(x:-117.3519964316712f32, y:52.30693919915002f32),
-        coord!(x:-117.3165476765753f32, y:52.30866462880422f32),
+    let p_2_4km = (
+        coord!(x:-117.351_996_431_671_2_f32, y:52.306_939_199_150_02_f32),
+        coord!(x:-117.316_547_676_575_3_f32, y:52.308_664_628_804_22_f32),
     );
 
-    let _67km = (
-        coord!(x:22.02060050752248f32, y:17.32531643138395f32),
-        coord!(x:22.6498898241764f32, y:17.31391991428638f32),
+    let p_67km = (
+        coord!(x:22.020_600_507_522_48_f32, y:17.325_316_431_383_95_f32),
+        coord!(x:22.649_889_824_176_4_f32, y:17.313_919_914_286_38_f32),
     );
 
-    let _103km = (
-        coord!(x:95.15915866746103f32, y:38.89938117857166f32),
-        coord!(x:94.615374082193f32, y:39.72746075951511f32),
+    let p_103km = (
+        coord!(x:95.159_158_667_461_03_f32, y:38.899_381_178_571_66_f32),
+        coord!(x:94.615_374_082_193_f32, y:39.727_460_759_515_11_f32),
     );
 
     // Distance between each elevation sample
-    let _90m = 90.0;
+    let d_90m = 90.0;
 
     group.bench_with_input(
         "2.4_km",
-        &(&tile_source, _90m, _2_4km),
+        &(&tile_source, d_90m, p_2_4km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -55,13 +55,13 @@ fn memmap_terrain_profile_f32(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 
     group.bench_with_input(
         "67_km",
-        &(&tile_source, _90m, _67km),
+        &(&tile_source, d_90m, p_67km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -72,13 +72,13 @@ fn memmap_terrain_profile_f32(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 
     group.bench_with_input(
         "103_km",
-        &(&tile_source, _90m, _103km),
+        &(&tile_source, d_90m, p_103km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -89,7 +89,7 @@ fn memmap_terrain_profile_f32(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 }
@@ -99,27 +99,27 @@ fn memmap_terrain_profile_f64(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("Profile<f64>");
 
-    let _2_4km = (
-        coord!(x:-117.3519964316712f64, y:52.30693919915002f64),
-        coord!(x:-117.3165476765753f64, y:52.30866462880422f64),
+    let p_2_4km = (
+        coord!(x:-117.351_996_431_671_2_f64, y:52.306_939_199_150_02_f64),
+        coord!(x:-117.316_547_676_575_3_f64, y:52.308_664_628_804_22_f64),
     );
 
-    let _67km = (
-        coord!(x:22.02060050752248f64, y:17.32531643138395f64),
-        coord!(x:22.6498898241764f64, y:17.31391991428638f64),
+    let p_67km = (
+        coord!(x:22.020_600_507_522_48_f64, y:17.325_316_431_383_95_f64),
+        coord!(x:22.649_889_824_176_4_f64, y:17.313_919_914_286_38_f64),
     );
 
-    let _103km = (
-        coord!(x:95.15915866746103f64, y:38.89938117857166f64),
-        coord!(x:94.615374082193f64, y:39.72746075951511f64),
+    let p_103km = (
+        coord!(x:95.159_158_667_461_03_f64, y:38.899_381_178_571_66_f64),
+        coord!(x:94.615_374_082_193_f64, y:39.727_460_759_515_11_f64),
     );
 
     // Distance between each elevation sample
-    let _90m = 90.0;
+    let d_90m = 90.0;
 
     group.bench_with_input(
         "2.4_km",
-        &(&tile_source, _90m, _2_4km),
+        &(&tile_source, d_90m, p_2_4km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -130,13 +130,13 @@ fn memmap_terrain_profile_f64(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 
     group.bench_with_input(
         "67_km",
-        &(&tile_source, _90m, _67km),
+        &(&tile_source, d_90m, p_67km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -147,13 +147,13 @@ fn memmap_terrain_profile_f64(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 
     group.bench_with_input(
         "103_km",
-        &(&tile_source, _90m, _103km),
+        &(&tile_source, d_90m, p_103km),
         |b, (t, d, (s, e))| {
             b.iter(|| {
                 Profile::builder()
@@ -164,7 +164,7 @@ fn memmap_terrain_profile_f64(c: &mut Criterion) {
                     .normalize(true)
                     .build(t)
                     .unwrap()
-            })
+            });
         },
     );
 }

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -66,14 +66,14 @@
 //! **Output Data**
 //!
 //! Here's an externally generated plot (plotting not included in this
-//! crate) of `profile`'s [los_elev_m] and [terrain_elev_m] over its
-//! [distances_m]:
+//! crate) of `profile`'s [`los_elev_m`] and [`terrain_elev_m`] over its
+//! [`distances_m`]:
 //!
 //! ![Lake Tahoe](https://github.com/JayKickliter/geoprof/assets/2551201/b8c94b4b-017c-4dd1-8a87-37c808ccea2b)
 //!
-//! [los_elev_m]: struct.Profile.html#structfield.los_elev_m
-//! [terrain_elev_m]: struct.Profile.html#structfield.terrain_elev_m
-//! [distances_m]: struct.Profile.html#structfield.distances_m
+//! [`los_elev_m`]: struct.Profile.html#structfield.los_elev_m
+//! [`terrain_elev_m`]: struct.Profile.html#structfield.terrain_elev_m
+//! [`distances_m`]: struct.Profile.html#structfield.distances_m
 
 mod constants;
 mod error;

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -9,7 +9,7 @@
 //! Suppose we want to determine the terrain obstruction a ray will
 //! encounter when following the path on the map from east to west:
 //!
-//! <iframe src="https://www.google.com/maps/d/u/0/embed?mid=1Q4TbMv-ZmAa4Uf6FizvkhQD3Ww2A498&ehbc=2E312F" width="800" height="480"></iframe>
+//! <iframe src="https://www.google.com/maps/d/u/0/embed?mid=1Q4TbMv-ZmAa4Uf6FizvkhQD3Ww2A498&ehbc=2E312F" width="100%" height="480"></iframe>
 //!
 //! **Example Code**
 //!

--- a/terrain/src/lib.rs
+++ b/terrain/src/lib.rs
@@ -75,7 +75,7 @@
 //! [`terrain_elev_m`]: struct.Profile.html#structfield.terrain_elev_m
 //! [`distances_m`]: struct.Profile.html#structfield.distances_m
 
-mod constants;
+pub mod constants;
 mod error;
 mod math;
 mod profile;

--- a/terrain/src/math.rs
+++ b/terrain/src/math.rs
@@ -187,21 +187,21 @@ mod tests {
     fn test_haversine_iter() {
         let start = point!(x: -0.5, y: -0.5);
         let end = point!(x: 0.5, y: 0.5);
-        let step_size_m = 17472.510284442324;
+        let step_size_m = 17_472.510_284_442_324;
         let haversine = HaversineIter::new(start, step_size_m, end);
         assert_eq!(haversine.len(), 10);
-        assert_eq!(haversine.step_size_m(), step_size_m);
+        assert_relative_eq!(haversine.step_size_m(), step_size_m);
         let points = haversine.collect::<Vec<_>>();
         let expected = vec![
             point!(x: -0.5, y: -0.5),
-            point!(x: -0.38888498879915234, y: -0.3888908388952553),
-            point!(x: -0.2777729026876084, y: -0.2777802152664852),
-            point!(x: -0.1666629058941368, y: -0.16666854700519793),
-            point!(x: -0.05555416267893612, y: -0.055556251975400386),
-            point!(x: 0.05555416267893612, y: 0.055556251975400386),
-            point!(x: 0.1666629058941367, y: 0.16666854700519784),
-            point!(x: 0.27777290268760824, y: 0.2777802152664851),
-            point!(x: 0.3888849887991523, y: 0.3888908388952552),
+            point!(x: -0.388_884_988_799_152_34, y: -0.388_890_838_895_255_3),
+            point!(x: -0.277_772_902_687_608_4, y: -0.277_780_215_266_485_2),
+            point!(x: -0.166_662_905_894_136_8, y: -0.166_668_547_005_197_93),
+            point!(x: -0.055_554_162_678_936_12, y: -0.055_556_251_975_400_386),
+            point!(x: 0.055_554_162_678_936_12, y: 0.055_556_251_975_400_386),
+            point!(x: 0.166_662_905_894_136_7, y: 0.166_668_547_005_197_84),
+            point!(x: 0.277_772_902_687_608_24, y: 0.277_780_215_266_485_1),
+            point!(x: 0.388_884_988_799_152_3, y: 0.388_890_838_895_255_2),
             point!(x: 0.5, y: 0.5),
         ];
         assert_eq!(points, expected);
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_elevation_angle() {
         assert_relative_eq!(
-            0.10016734235964142,
+            0.100_167_342_359_641_42,
             elevation_angle(1.0, 1.0, 1.1),
             epsilon = f64::EPSILON
         );

--- a/terrain/src/profile.rs
+++ b/terrain/src/profile.rs
@@ -75,36 +75,42 @@ where
     f64: From<C>,
 {
     /// Start point of the path (required).
+    #[must_use]
     pub fn start(mut self, coord: Coord<C>) -> Self {
         self.start = Some(coord);
         self
     }
 
     /// Starting altitude above ground (meters, defaults to 0).
+    #[must_use]
     pub fn start_alt(mut self, meters: C) -> Self {
         self.start_alt_m = meters;
         self
     }
 
     /// Maximum distance between points (required).
+    #[must_use]
     pub fn max_step(mut self, meters: C) -> Self {
         self.max_step_m = Some(meters);
         self
     }
 
     /// End point of the path (required).
+    #[must_use]
     pub fn end(mut self, coord: Coord<C>) -> Self {
         self.end = Some(coord);
         self
     }
 
     /// Starting altitude above ground (meters, defaults to 0).
+    #[must_use]
     pub fn end_alt(mut self, meters: C) -> Self {
         self.end_alt_m = meters;
         self
     }
 
     /// Add earth curvature (defaults to false).
+    #[must_use]
     pub fn earth_curve(mut self, add_curve: bool) -> Self {
         self.earth_curve = add_curve;
         self
@@ -113,6 +119,7 @@ where
     /// Place virtual earth curve as the highest and center point of
     /// the output (defaults to false; has no effect if `earth_curve`
     /// is `false`).
+    #[must_use]
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
         self
@@ -284,20 +291,20 @@ mod tests {
     #[test]
     fn test_profile() {
         let start = Coord {
-            x: -71.30830716441369,
-            y: 44.28309806603165,
+            x: -71.308_307_164_413_69,
+            y: 44.283_098_066_031_65,
         };
         let end = Coord {
-            x: -71.2972073283768,
-            y: 44.25628098424278,
+            x: -71.297_207_328_376_8,
+            y: 44.256_280_984_242_78,
         };
 
         let tile_source = Tiles::new(crate::three_arcsecond_dir(), TileMode::MemMap).unwrap();
 
-        let _90m = 90.0;
+        let d90m = 90.0;
         let profile = Profile::builder()
             .start(start)
-            .max_step(_90m)
+            .max_step(d90m)
             .end(end)
             .build(&tile_source)
             .unwrap();

--- a/terrain/src/profile.rs
+++ b/terrain/src/profile.rs
@@ -1,4 +1,5 @@
 use crate::{
+    constants::MEAN_EARTH_RADIUS,
     math::{elevation_angle, linspace, HaversineIter},
     TerrainError, Tiles,
 };
@@ -40,6 +41,7 @@ where
             end_alt_m: C::zero(),
             earth_curve: false,
             normalize: false,
+            earth_radius: C::from(MEAN_EARTH_RADIUS).unwrap(),
         }
     }
 }
@@ -67,6 +69,9 @@ pub struct ProfileBuilder<C: CoordFloat = f32> {
     /// the output (defaults to false; has no effect if `earth_curve`
     /// is `false`).
     normalize: bool,
+
+    /// Earth radius, defaults to [MEAN_EARTH_RADIUS].
+    earth_radius: C,
 }
 
 impl<C> ProfileBuilder<C>
@@ -122,6 +127,13 @@ where
     #[must_use]
     pub fn normalize(mut self, normalize: bool) -> Self {
         self.normalize = normalize;
+        self
+    }
+
+    /// Earth radius, defaults to [`MEAN_EARTH_RADIUS`].
+    #[must_use]
+    pub fn earth_radius(mut self, earth_radius_m: C) -> Self {
+        self.earth_radius = earth_radius_m;
         self
     }
 


### PR DESCRIPTION
This PR adds a new crate `propah`, geared toward radio propagation. I've moved some of terrain's functionality to it.

Key features:

1. adds fresnel zone (closes #10)
2. makes earth radius as runtime (closes #15)
