### PR TITLE
[terrain] propperly take supplied earth radius into account

### DIFF
--- a/propah/src/p2p.rs
+++ b/propah/src/p2p.rs
@@ -198,6 +198,7 @@ where
             .end_alt(self.end_alt_m)
             .earth_curve(self.earth_curve)
             .normalize(self.normalize)
+            .earth_radius(self.earth_radius)
             .build(tiles)?;
 
         // Unwrap is fine as profiles always have at least two points.

--- a/terrain/src/math.rs
+++ b/terrain/src/math.rs
@@ -148,11 +148,10 @@ where
 }
 
 /// Returns the up/down angle (in radians) from a to b.
-pub fn elevation_angle<T>(start_elev_m: T, distance_m: T, end_elev_m: T) -> T
+pub fn elevation_angle<T>(start_elev_m: T, distance_m: T, end_elev_m: T, earth_radius: T) -> T
 where
     T: Float + FloatConst,
 {
-    let earth_radius = T::from(MEAN_EARTH_RADIUS).unwrap();
     let a = distance_m;
     let b = start_elev_m + earth_radius;
     let c = end_elev_m + earth_radius;
@@ -211,7 +210,7 @@ mod tests {
     fn test_elevation_angle() {
         assert_relative_eq!(
             0.100_167_342_359_641_42,
-            elevation_angle(1.0, 1.0, 1.1),
+            elevation_angle(1.0, 1.0, 1.1, super::MEAN_EARTH_RADIUS),
             epsilon = f64::EPSILON
         );
     }

--- a/terrain/src/profile.rs
+++ b/terrain/src/profile.rs
@@ -189,13 +189,14 @@ where
             let now = std::time::Instant::now();
             if self.earth_curve {
                 // https://www.trailnotes.org/SizeOfTheEarth/
-                let earth_radius = C::from(crate::constants::MEAN_EARTH_RADIUS).unwrap();
+                let earth_radius = self.earth_radius;
                 let start_elev_alt =
                     *terrain_elev_m.first().unwrap() + C::from(self.start_alt_m).unwrap();
                 let start_radius_m = earth_radius + start_elev_alt;
                 let end_elev_alt =
                     *terrain_elev_m.last().unwrap() + C::from(self.end_alt_m).unwrap();
-                let elev_angle_rad = elevation_angle(start_elev_alt, distance_m, end_elev_alt);
+                let elev_angle_rad =
+                    elevation_angle(start_elev_alt, distance_m, end_elev_alt, self.earth_radius);
 
                 let (nb, nm) = if self.normalize {
                     let nb = -start_elev_alt;


### PR DESCRIPTION
The value wasn't being passed to all the places that needed it.